### PR TITLE
Add JSON response mode and optimize Pinecone index

### DIFF
--- a/routes/chatbot.py
+++ b/routes/chatbot.py
@@ -58,6 +58,7 @@ def chat():
     data = request.json
     session_id = data.get("session_id")
     user_input = data.get("input")
+    response_format = data.get("response_format", "html")
 
     if not session_id:
         return jsonify({"error": "session_id is required"}), 400
@@ -71,7 +72,7 @@ def chat():
     if not chat_service:
         return jsonify({"error": "Chat service not found for session_id"}), 400
 
-    response = chat_service.handle_user_query(user_input)
+    response = chat_service.handle_user_query(user_input, response_format)
 
     # Salva la conversazione nel database
     conversation = Conversation(session_id=session_id, user_input=user_input, bot_response=response)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -34,7 +34,9 @@ for name in [
 
 
 # Ensure the application uses an in-memory database during import
-os.environ.setdefault('DATABASE_URI', 'sqlite:///:memory:')
+# Force the app to use an in-memory SQLite DB for testing even if a
+# DATABASE_URI is already defined in the environment.
+os.environ['DATABASE_URI'] = 'sqlite:///:memory:'
 
 pinecone = types.ModuleType('pinecone')
 pinecone.Pinecone = object


### PR DESCRIPTION
## Summary
- allow specifying `response_format` for chatbot messages
- ensure Pinecone indexes are initialized with correct dimension
- support JSON product suggestions via CustomRecommendationTool and prompt updates
- force SQLite database in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684090b30fb48323b1fca3a98d9986c8